### PR TITLE
Adding status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Python LSIF Indexer
+# Python LSIF Indexer ![](https://img.shields.io/badge/status-development-yellow)
 
 🚨 This implementation is in its infancy and conforms to the [0.4.0 draft of the LSIF spec](https://github.com/Microsoft/language-server-protocol/blob/master/indexFormat/specification.md).
 


### PR DESCRIPTION
Status badge helps inform users of the state of the tool, the badge should match status listed in: https://lsif.dev/